### PR TITLE
feat: response decode

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+github_checks:
+  annotations: false
+
+coverage:
+  status:
+    patch: off
+    project: off
+
+comment:
+  layout: "diff, flags, files"


### PR DESCRIPTION
This PR introduces a proper Decode implementation for Response objects and refactors the existing Request.Decode logic for consistency and clarity.

Add Response.Decode to populate fields, validate response codes, and extract options.
Simplify Response.String by removing LocationPath and LocationQuery.
Refactor Request.Decode comments and reorder field assignments for clarity.