### PR TITLE
feat: unrecognized option max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,8 @@ The library supports **UDP** and **DTLS** protocols.
 
 ## Structure
 
-The `Message` type represents a complete CoAP message, encapsulating the protocol's header, options, and payload.
+### Encoding
+
+* `Message` type represents a complete CoAP message, encapsulating the protocol's header, options, and payload.
+* `Request` type models a CoAP request, adding fields and validations for response code and commonly used options.
+* `Response` type models a CoAP response, adding fields and validations for request method and commonly used options.

--- a/option.go
+++ b/option.go
@@ -352,7 +352,7 @@ func (o *Option) Decode(data []byte, prev uint16, opts DecodeOptions) ([]byte, e
 
 	// lookup option definition
 	code := prev + delta
-	o.OptionDef = opts.Schema.Option(code)
+	o.OptionDef = opts.Schema.Option(code, opts.MaxOptionLength)
 
 	// check length against option definition
 	o.MaxLen = min(o.OptionDef.MaxLen, opts.MaxOptionLength)

--- a/option_test.go
+++ b/option_test.go
@@ -92,7 +92,7 @@ func TestOptionRoundtrip(t *testing.T) {
 		},
 		{
 			name:   "unrecognized option",
-			option: UnrecognizedOptionDef(0xFFFF),
+			option: UnrecognizedOptionDef(0xFFFF, MaxOptionLength),
 			data:   []byte{0xE0, 0xFE, 0xF2},
 			value:  []byte(nil),
 		},

--- a/optiondef.go
+++ b/optiondef.go
@@ -1,5 +1,7 @@
 package coap
 
+import "fmt"
+
 // revive:disable:exported
 
 var (
@@ -57,11 +59,11 @@ const (
 )
 
 // UnrecognizedOptionDef creates an OptionDef for an unrecognized option code.
-func UnrecognizedOptionDef(code uint16) OptionDef {
+func UnrecognizedOptionDef(code uint16, maxLen uint16) OptionDef {
 	return OptionDef{
 		Code:        code,
 		ValueFormat: ValueFormatOpaque,
-		MaxLen:      1034,
+		MaxLen:      maxLen,
 	}
 }
 
@@ -87,7 +89,12 @@ func (o OptionDef) NoCacheKey() bool {
 
 // String implements fmt.Stringer.
 func (o OptionDef) String() string {
-	return o.Name
+	switch {
+	case o.Recognized():
+		return fmt.Sprintf("Option(Name=%s, Code=%d, ValueFormat=%s, MinLen=%d, MaxLen=%d)", o.Name, o.Code, o.ValueFormat, o.MinLen, o.MaxLen)
+	default:
+		return fmt.Sprintf("Option(Code=%d, ValueFormat=%s, MaxLen=%d)", o.Code, o.ValueFormat, o.MaxLen)
+	}
 }
 
 var valueFormatString = map[ValueFormat]string{

--- a/optiondef_test.go
+++ b/optiondef_test.go
@@ -10,23 +10,27 @@ func TestOptionDefMethods(t *testing.T) {
 		critical   bool
 		unsafe     bool
 		noCacheKey bool
+		str        string
 	}{
 		{
 			name:       "critical",
 			def:        IfMatch,
 			recognized: true,
 			critical:   true,
+			str:        "Option(Name=IfMatch, Code=1, ValueFormat=Opaque, Repeatable=false, MinLen=0, MaxLen=8)",
 		},
 		{
 			name:       "no-cache-key",
 			def:        Size1,
 			recognized: true,
 			noCacheKey: true,
+			str:        "Option(Name=Size1, Code=1, ValueFormat=Uint, Repeatable=false, MinLen=0, MaxLen=0)",
 		},
 		{
 			name:   "unrecognized, unsafe",
-			def:    UnrecognizedOptionDef(MaxAge.Code),
+			def:    UnrecognizedOptionDef(MaxAge.Code, MaxOptionLength),
 			unsafe: true,
+			str:    "Option(Code=14, ValueFormat=Opaque, MaxLen=1024)",
 		},
 	}
 

--- a/options.go
+++ b/options.go
@@ -401,7 +401,7 @@ func (o *Options) Decode(data []byte, opts DecodeOptions) ([]byte, error) {
 		// Each occurence of non-repeatable option has to be treated as unrecognized
 		// https://datatracker.ietf.org/doc/html/rfc7252#section-5.4.5
 		if !option.Repeatable && option.Code == prev {
-			option.OptionDef = UnrecognizedOptionDef(option.Code)
+			option.OptionDef = UnrecognizedOptionDef(option.Code, opts.MaxOptionLength)
 		}
 
 		prev = option.Code

--- a/schema.go
+++ b/schema.go
@@ -78,10 +78,10 @@ func (s *Schema) AddMediaTypes(mediaTypes ...MediaType) *Schema {
 // Option retrieves an option by code.
 //
 // If the option is not recognized, it returns an UnrecognizedOptionDef with given code.
-func (s *Schema) Option(code uint16) OptionDef {
+func (s *Schema) Option(code uint16, maxLen uint16) OptionDef {
 	option, ok := s.options[code]
 	if !ok {
-		return UnrecognizedOptionDef(code)
+		return UnrecognizedOptionDef(code, maxLen)
 	}
 
 	return option


### PR DESCRIPTION
Adds support for a custom maximum length for unrecognized CoAP options so they no longer use a hardcoded default.

Extended Schema.Option and UnrecognizedOptionDef to take a maxLen parameter
Propagated MaxOptionLength through decoding paths and updated String() formatting
Updated tests and README to reflect the new behavior